### PR TITLE
Add worker and queue (with celery and rabbitmq)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 services:
     - postgresql
+    # rabbitmq needs sudo in travis, but sudo makes travis checks take forever.
+    # instead, run celery on redis since it doesn't need sudo. hopefully this
+    # will work fine, but it may become an issue since we want to use rabbitmq
+    - redis-server
 
 language: python
 python:
@@ -12,9 +16,7 @@ env:
 install: "pip install tox"
 
 before_script:
-    - psql -c 'create database "tetra-db";' -U postgres
     - ./travis-setup.sh
-    - gunicorn --daemon -t 120 --bind 127.0.0.1:7374 tetra.app:application
 
 script: tox
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,5 +4,4 @@ WORKDIR /tetra/
 ADD requirements.txt /tetra/requirements.txt
 RUN pip install -r requirements.txt
 ADD . /tetra
-EXPOSE 7374
-CMD gunicorn --reload -t 120 --bind 0.0.0.0:7374 tetra.app:application
+RUN adduser --disabled-password --gecos '' tetra-worker

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,9 @@ UNAME := $(shell uname)
 
 # the image and container are both named this
 DOCKER_TAG := tetra-api
+DOCKER_WORKER_TAG := tetra-worker
 DOCKER_DB_TAG := tetra-db
+DOCKER_QUEUE_TAG := tetra-queue
 
 # set some variables for docker-machine, which we need outside of Linux
 ifeq ($(UNAME), Linux)
@@ -20,17 +22,20 @@ else
 endif
 
 help:
-	@echo 'Api commands:'
+	@echo 'Commands:'
 	@echo '  start                      - start the tetra api, running locally'
-	@echo 'Test commands:'
 	@echo '  test                       - run tests (you must first write tetra-test.conf)'
+	@echo '  rabbitmq-admin-ui          - open the rabbitmq management interface in a browser'
 	@echo 'Docker commands:'
-	@echo '  docker-build               - build the api docker image ($(DOCKER_TAG))'
-	@echo '  docker-dev                 - build/run the api and postgres images/containers for a dev environment'
+	@echo '  docker-build               - build all docker images for a dev environment'
+	@echo '  docker-dev                 - build/run all images/containers for a dev environment'
+	@echo '  docker-restart-worker      - restart the worker container'
 	@echo '  docker-db                  - run the postgres docker container in background ($(DOCKER_DB_TAG))'
+	@echo '  docker-queue               - run the rabbitmq docker container in background ($(DOCKER_QUEUE_TAG))'
+	@echo '  docker-logs                - follow the logs from all containers'
 	@echo '  docker-ps                  - list running docker containers'
 	@echo '  docker-stop                - stop and rm the containers ($(DOCKER_TAG), $(DOCKER_DB_TAG))'
-	@echo '  docker-port                - display the real <ip>:<port> for the database'
+	@echo '  docker-port                - display the real <ip>:<port> for different containers'
 	@echo '  docker-machine-create      - start the boot2docker vm ($(DOCKER_MACHINE_NAME))'
 	@echo '                               NOTE: this is a no-op on linux.'
 	@echo '  docker-machine-rm          - remove the boot2docker vm ($(DOCKER_MACHINE_NAME))'
@@ -47,13 +52,22 @@ test:
 	py.test -v ./tests
 
 docker-build: docker-machine-create
-	$(WITH_DOCKER_ENV) && docker build -t $(DOCKER_TAG) .
+	$(WITH_DOCKER_ENV) && docker-compose -f docker-compose.yml -f docker-compose.dev.yml build
 
 docker-dev:
-	$(WITH_DOCKER_ENV) && docker-compose -f docker-compose.yml -f docker-compose.dev.yml up api
+	$(WITH_DOCKER_ENV) && docker-compose -f docker-compose.yml -f docker-compose.dev.yml up api worker
+
+docker-restart-worker:
+	$(WITH_DOCKER_ENV) && docker-compose -f docker-compose.yml -f docker-compose.dev.yml restart worker
 
 docker-db:
 	$(WITH_DOCKER_ENV) && docker-compose -f docker-compose.yml -f docker-compose.dev.yml up -d db
+
+docker-queue:
+	$(WITH_DOCKER_ENV) && docker-compose -f docker-compose.yml -f docker-compose.dev.yml up -d queue
+
+docker-logs:
+	$(WITH_DOCKER_ENV) && docker-compose -f docker-compose.yml -f docker-compose.dev.yml logs -f
 
 docker-ps:
 	$(WITH_DOCKER_ENV) && docker ps
@@ -63,16 +77,34 @@ docker-stop:
 
 docker-port:
 ifeq ($(UNAME), Linux)
-	$(WITH_DOCKER_ENV) && docker port $(DOCKER_DB_TAG) 5432
+	echo API=$(shell $(WITH_DOCKER_ENV) && docker port $(DOCKER_TAG) 7374)
+	echo DB=$(shell $(WITH_DOCKER_ENV) && docker port $(DOCKER_DB_TAG) 5432)
+	echo QUEUE=$(shell $(WITH_DOCKER_ENV) && docker port $(DOCKER_QUEUE_TAG) 5672)
 else
-	@echo `docker-machine ip $(DOCKER_MACHINE_NAME)`:$(shell \
+	@echo API=`docker-machine ip $(DOCKER_MACHINE_NAME)`:$(shell \
+		$(WITH_DOCKER_ENV) && docker port $(DOCKER_TAG) 7374 | cut -d':' -f 2 \
+	)
+	@echo DB=`docker-machine ip $(DOCKER_MACHINE_NAME)`:$(shell \
 		$(WITH_DOCKER_ENV) && docker port $(DOCKER_DB_TAG) 5432 | cut -d':' -f 2 \
+	)
+	@echo QUEUE=`docker-machine ip $(DOCKER_MACHINE_NAME)`:$(shell \
+		$(WITH_DOCKER_ENV) && docker port $(DOCKER_QUEUE_TAG) 5672 | cut -d':' -f 2 \
 	)
 endif
 
 docker-postgres-shell:
 	$(WITH_DOCKER_ENV) && docker exec -it $(DOCKER_DB_TAG) \
 		bash -c 'PGPASSWORD=password psql -U postgres'
+
+rabbitmq-admin-ui:
+	@echo "To login, check docker-compose.yml for RABBITMQ_DEFAULT_USER and RABBITMQ_DEFAULT_PASS"
+ifeq ($(UNAME), Linux)
+	xdg-open http://`docker port $(DOCKER_QUEUE_TAG) 15672`
+else
+	open http://`docker-machine ip $(DOCKER_MACHINE_NAME)`:$(shell \
+		$(WITH_DOCKER_ENV) && docker port $(DOCKER_QUEUE_TAG) 15672 | cut -d':' -f 2 \
+	)
+endif
 
 docker-machine-create:
 ifneq ($(DOCKER_MACHINE_CHECK_NAME), $(DOCKER_MACHINE_NAME))

--- a/Makefile
+++ b/Makefile
@@ -77,9 +77,9 @@ docker-stop:
 
 docker-port:
 ifeq ($(UNAME), Linux)
-	echo API=$(shell $(WITH_DOCKER_ENV) && docker port $(DOCKER_TAG) 7374)
-	echo DB=$(shell $(WITH_DOCKER_ENV) && docker port $(DOCKER_DB_TAG) 5432)
-	echo QUEUE=$(shell $(WITH_DOCKER_ENV) && docker port $(DOCKER_QUEUE_TAG) 5672)
+	@echo API=$(shell $(WITH_DOCKER_ENV) && docker port $(DOCKER_TAG) 7374)
+	@echo DB=$(shell $(WITH_DOCKER_ENV) && docker port $(DOCKER_DB_TAG) 5432)
+	@echo QUEUE=$(shell $(WITH_DOCKER_ENV) && docker port $(DOCKER_QUEUE_TAG) 5672)
 else
 	@echo API=`docker-machine ip $(DOCKER_MACHINE_NAME)`:$(shell \
 		$(WITH_DOCKER_ENV) && docker port $(DOCKER_TAG) 7374 | cut -d':' -f 2 \

--- a/README.md
+++ b/README.md
@@ -4,21 +4,72 @@
 
 # Using the makefile
 
-The makefile contains a bunch of commands for managing a docker container for
-the database. In non-linux places, it uses docker-machine to run docker in a
-vm.
+The makefile contains a bunch of commands for managing a docker containers for
+all of tetra's services. You will need `docker-compose` installed. In non-linux
+places, it uses `docker-machine` to run docker containers in a linux vm.
 
-Run a `make help` to see the makefile targets.
+First, run a `make help` to see the makefile targets.
 
-To build and run the image/container
+To build the containers:
 
     $ make docker-build
-    $ make docker-run
 
-To see the ip and port of your postgres server:
+To build/run the containers:
+
+    $ make docker-dev
+
+_Note: The db and queue take several seconds to start up. You may get errors in
+the api and worker on the first start up becuase of this. Restarting the api
+and worker should fix this._
+
+To see the `<ip>:<port>` of different services:
 
     $ make docker-port
 
 To get a postgres shell in the container:
 
     $ make docker-postgres-shell
+
+
+# Configuring tetra
+
+Tetra reads all of its config from a `tetra.conf` file. The complete list of
+options is in `tetra/config.py`. Here's an example `tetra.conf` file:
+
+    [sqlalchemy]
+    engine = postgres
+    host = localhost
+    port = 5432
+    username = postgres
+    password = password
+    database = tetra-db
+
+    [api]
+    default_limit = 25
+
+    [queue]
+    broker_url = amqp://tetra:password@localhost:5672//
+
+Tip: When using the docker dev environment, you can use the names of the
+services in the `docker-compose.yml` as hostnames:
+
+    host = db
+    ...
+    broker_url = amqp://tetra:password@queue:5672//
+
+# Running the tests
+
+The tests look for a `tetra-test.conf` file. The complete list of options is in
+`tests/config.py`. Here's an example `tetra-test.conf` file:
+
+    [api]
+    base_url = http://localhost:7374
+
+The you can either use `tox` to run the tests:
+
+    tox -e functional
+
+Or you can use the makefile:
+
+    $ pip install -r test-requirements.txt
+    $ make test

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -2,4 +2,7 @@ version: '2'
 services:
   api:
     volumes:
-     - .:/tetra
+      - .:/tetra
+  worker:
+    volumes:
+      - .:/tetra

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,19 @@ services:
       - db
     links:
       - db
+    command: |
+      bash -c "export PYTHONUNBUFFERED=1 && gunicorn --reload -t 120 --bind 0.0.0.0:7374 tetra.app:application"
+  worker:
+    image: tetra-api
+    container_name: tetra-worker
+    depends_on:
+      - queue
+    links:
+      - queue
+    # celery has a `--auotreload` flag that doesn't reload dependent modules,
+    # so it doesn't work. use `docker-compose restart worker` instead.
+    command: |
+      su -m tetra-worker -c "celery --app=tetra.worker.app worker --loglevel=INFO"
   db:
     image: postgres:9.5
     container_name: tetra-db
@@ -18,3 +31,12 @@ services:
     environment:
       POSTGRES_PASSWORD: password
       POSTGRES_DB: tetra-db
+  queue:
+    image: rabbitmq:3.6-management
+    container_name: tetra-queue
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+    environment:
+      RABBITMQ_DEFAULT_USER: tetra
+      RABBITMQ_DEFAULT_PASS: password

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ psycopg2
 sqlalchemy
 oslo.config
 xunitparser
+celery

--- a/tests/api/test_worker.py
+++ b/tests/api/test_worker.py
@@ -1,0 +1,9 @@
+from tests.base import BaseTetraTest
+
+
+class TestWorker(BaseTetraTest):
+
+    def test_workers_ping(self):
+        resp = self.client.workers_ping()
+        self.assertEqual(resp.status_code, 200)
+        self.assertIsNotNone(resp.json()['result'])

--- a/tests/api/test_worker.py
+++ b/tests/api/test_worker.py
@@ -6,4 +6,4 @@ class TestWorker(BaseTetraTest):
     def test_workers_ping(self):
         resp = self.client.workers_ping()
         self.assertEqual(resp.status_code, 200)
-        self.assertIsNotNone(resp.json()['result'])
+        self.assertEqual(resp.json()['result'], 7374)

--- a/tests/client.py
+++ b/tests/client.py
@@ -87,9 +87,18 @@ class ResultClientMixin(BaseClient):
         return requests.delete(url, params=params)
 
 
+class WorkerClientMixin(BaseClient):
+
+    @log_response
+    def workers_ping(self, params=None):
+        url = self.url('workers', 'ping')
+        return requests.get(url, params=params)
+
+
 class TetraClient(
     ProjectClientMixin,
     BuildClientMixin,
     ResultClientMixin,
+    WorkerClientMixin,
 ):
     pass

--- a/tetra/app.py
+++ b/tetra/app.py
@@ -22,6 +22,9 @@ from api.resources import (
     BuildsResource,
     ProjectsResource,
 )
+from worker.resources import (
+    WorkerPingResource,
+)
 
 
 class TetraAPI(falcon.API):
@@ -32,6 +35,7 @@ class TetraAPI(falcon.API):
         ResultResource(),
         BuildsResource(),
         ProjectsResource(),
+        WorkerPingResource(),
     ]
 
     def __init__(self):

--- a/tetra/config.py
+++ b/tetra/config.py
@@ -24,6 +24,7 @@ _LOCATIONS = (
 
 cfg.CONF.register_group(cfg.OptGroup('sqlalchemy'))
 cfg.CONF.register_group(cfg.OptGroup('api'))
+cfg.CONF.register_group(cfg.OptGroup('queue'))
 
 cfg.CONF.register_opts([
     cfg.StrOpt('engine', default='postgres'),
@@ -37,6 +38,11 @@ cfg.CONF.register_opts([
 cfg.CONF.register_opts([
     cfg.IntOpt('default_limit', default=25),
 ], group='api')
+
+cfg.CONF.register_opts([
+    cfg.StrOpt('broker_url', default='amqp://tetra@localhost:5672//',
+               help='The location of RabbitMQ for celery'),
+], group='queue')
 
 
 def _find_config_file(locations):

--- a/tetra/worker/app.py
+++ b/tetra/worker/app.py
@@ -1,0 +1,29 @@
+"""
+Copyright 2016 Rackspace
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from celery import Celery
+
+from tetra.config import cfg
+
+CONF = cfg.CONF
+
+app = Celery('tetra', include=['tetra.worker.tasks'])
+
+app.conf.BROKER_URL = CONF.queue.broker_url
+app.conf.CELERY_TASK_SERIALIZER = 'json'
+app.conf.CELERY_RESULT_SERIALIZER = 'json'
+app.conf.CELERY_ACCEPT_CONTENT = ['json']
+app.conf.CELERY_RESULT_BACKEND = 'rpc://'
+app.conf.CELERY_RESULT_PERSISTENT = False

--- a/tetra/worker/resources.py
+++ b/tetra/worker/resources.py
@@ -1,0 +1,33 @@
+"""
+Copyright 2016 Rackspace
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import logging
+import json
+import falcon
+
+from tetra.worker import tasks
+from tetra.api.resources import Resources, Resource
+
+LOG = logging.getLogger(__name__)
+
+
+class WorkerPingResource(object):
+    ROUTE = "/workers/ping"
+
+    def on_get(self, req, resp):
+        resp.status = falcon.HTTP_200
+        task = tasks.ping.delay()
+        value = task.get(timeout=5)
+        resp.body = json.dumps({"result": value})

--- a/tetra/worker/resources.py
+++ b/tetra/worker/resources.py
@@ -18,7 +18,6 @@ import json
 import falcon
 
 from tetra.worker import tasks
-from tetra.api.resources import Resources, Resource
 
 LOG = logging.getLogger(__name__)
 

--- a/tetra/worker/tasks.py
+++ b/tetra/worker/tasks.py
@@ -1,0 +1,21 @@
+"""
+Copyright 2016 Rackspace
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from tetra.worker.app import app as worker_app
+
+
+@worker_app.task
+def ping():
+    return 7374

--- a/travis-setup.sh
+++ b/travis-setup.sh
@@ -12,6 +12,9 @@ database = tetra-db
 
 [api]
 default_limit = 25
+
+[queue]
+broker_url = redis://localhost:6379/0
 EOF
 
 cat <<EOF > tetra-test.conf
@@ -19,4 +22,12 @@ cat <<EOF > tetra-test.conf
 base_url = http://localhost:7374
 EOF
 
+psql -c 'create database "tetra-db";' -U postgres
 pip install -r requirements.txt
+# required to use redis with celery
+pip install -U celery[redis]
+
+# the effect of this is we see our print statements printed immediately
+export PYTHONUNBUFFERED=1
+gunicorn --daemon -t 120 --bind 127.0.0.1:7374 tetra.app:application
+celery --detach --app=tetra.worker.app worker --loglevel=INFO


### PR DESCRIPTION
- Adds a rabbitmq container (with admin ui) and a worker container running a celery worker
- Adds a `/workers/ping` api call + a test, and just enough celery bits to get this test passing
- Updates the makefile to start the worker and to do a few other things
- Updates the README with hopefully enough info to start the containers and run tests
- Updates travis to start celery workers
