### PR TITLE
Add basic views to the dashboard (projects, builds, results)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+*node_modules*
+*/node_modules
+*/*/node_modules
+docker-compose*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     links:
       - db
     command: |
-      bash -c "export PYTHONUNBUFFERED=1 && gunicorn --reload -t 120 --bind 0.0.0.0:7374 tetra.app:application"
+      bash -c "export PYTHONUNBUFFERED=1 && gunicorn --reload -t 120 --bind 0.0.0.0:7374 --access-logfile - tetra.app:application"
   worker:
     image: tetra-api
     container_name: tetra-worker

--- a/ui/.dockerignore
+++ b/ui/.dockerignore
@@ -1,0 +1,5 @@
+.git
+*node_modules*
+*/node_modules
+*/*/node_modules
+docker-compose*

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,5 +1,5 @@
 FROM nginx:stable-alpine
 
 ADD . /usr/share/nginx/html
-COPY nginx.conf /etc/ngingx/nginx.conf
+COPY nginx.conf /etc/nginx/conf.d/
 RUN chown nginx:nginx -R /usr/share/nginx/html

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,5 +1,5 @@
 FROM nginx:stable-alpine
 
 ADD . /usr/share/nginx/html
-COPY nginx.conf /etc/nginx/conf.d/
+COPY nginx.conf /etc/nginx/conf.d/default.conf
 RUN chown nginx:nginx -R /usr/share/nginx/html

--- a/ui/app/builds-table.jsx
+++ b/ui/app/builds-table.jsx
@@ -3,13 +3,20 @@ import ResourceTable from './resource-table';
 
 var BuildsTable = React.createClass({
 
-    columnKeys: ["Id", "Name", "Build_url", "Region", "Environment"],
+    columnKeys: [
+        "Id", "Project_id", "Name", "Build_url", "Region", "Environment"
+    ],
 
     render: function() {
         return (
             <ResourceTable resources={this.props.builds}
-                           columnKeys={this.columnKeys} />
+                           columnKeys={this.columnKeys}
+                           getRoute={this.getRoute} />
         );
+    },
+
+    getRoute: function(build) {
+        return "/" + build.project_id + "/builds/" + build.id + "/results";
     },
 
 });

--- a/ui/app/builds-table.jsx
+++ b/ui/app/builds-table.jsx
@@ -3,13 +3,17 @@ import ResourceTable from './resource-table';
 
 var BuildsTable = React.createClass({
 
+    columnTitles: [
+        "Id", "Project Id", "Name", "Build Url", "Region", "Environment",
+    ],
     columnKeys: [
-        "Id", "Project_id", "Name", "Build_url", "Region", "Environment"
+        "id", "project_id", "name", "build_url", "region", "environment",
     ],
 
     render: function() {
         return (
             <ResourceTable resources={this.props.builds}
+                           columnTitles={this.columnTitles}
                            columnKeys={this.columnKeys}
                            getRoute={this.getRoute} />
         );

--- a/ui/app/builds-table.jsx
+++ b/ui/app/builds-table.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import ResourceTable from './resource-table';
+
+var BuildsTable = React.createClass({
+
+    columnKeys: ["Id", "Name", "Build_url", "Region", "Environment"],
+
+    render: function() {
+        return (
+            <ResourceTable resources={this.props.builds}
+                           columnKeys={this.columnKeys} />
+        );
+    },
+
+});
+
+export default BuildsTable;

--- a/ui/app/builds-table.jsx
+++ b/ui/app/builds-table.jsx
@@ -9,18 +9,22 @@ var BuildsTable = React.createClass({
     columnKeys: [
         "id", "project_id", "name", "build_url", "region", "environment",
     ],
+    columnLinks: {
+        name: function(build) {
+            return "/" + build.project_id + "/builds/" + build.id + "/results";
+        },
+        id: function(build) {
+            return "/" + build.project_id + "/builds/" + build.id + "/results";
+        },
+    },
 
     render: function() {
         return (
             <ResourceTable resources={this.props.builds}
                            columnTitles={this.columnTitles}
                            columnKeys={this.columnKeys}
-                           getRoute={this.getRoute} />
+                           columnLinks={this.columnLinks} />
         );
-    },
-
-    getRoute: function(build) {
-        return "/" + build.project_id + "/builds/" + build.id + "/results";
     },
 
 });

--- a/ui/app/builds-view.jsx
+++ b/ui/app/builds-view.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import BuildsTable from './builds-table';
+
+var BuildsView = React.createClass({
+
+    getInitialState: function() {
+        return {
+            builds: [],
+        }
+    },
+
+    componentDidMount: function() {
+        var url = "/api/" + this.props.project_id + "/builds";
+        this.buildsRequest = $.get(url, function(result) {
+            this.setState({
+                builds: result
+            })
+        }.bind(this))
+    },
+
+    componentWillUnmount: function() {
+        this.buildsRequest.abort();
+    },
+
+    render: function() {
+        return (
+            <div>
+                <h2 className="rs-page-title">Builds</h2>
+                <BuildsTable builds={this.state.builds} />
+            </div>
+        );
+    },
+});
+
+export default BuildsView;

--- a/ui/app/builds-view.jsx
+++ b/ui/app/builds-view.jsx
@@ -9,8 +9,12 @@ var BuildsView = React.createClass({
         }
     },
 
+    projectId: function() {
+        return this.props.params.project_id || this.props.project_id;
+    },
+
     componentDidMount: function() {
-        var url = "/api/" + this.props.project_id + "/builds";
+        var url = "/api/" + this.projectId() + "/builds";
         this.buildsRequest = $.get(url, function(result) {
             this.setState({
                 builds: result

--- a/ui/app/landing.jsx
+++ b/ui/app/landing.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import ProjectsTable from './projects-table';
+
+var Landing = React.createClass({
+
+    getInitialState: function() {
+        return {
+            projects: [{id: 1, name: "poo", pee: "wumbo"}],
+        }
+    },
+
+    componentDidMount: function() {
+        this.projectsRequest = $.get("/api/projects", function(result) {
+            this.setState({
+                projects: result
+            })
+        }.bind(this));
+    },
+
+    componentWillUnmount: function() {
+        this.projectsRequest.abort();
+    },
+
+    render: function() {
+        return (
+            <ProjectsTable projects={this.state.projects} />
+        );
+    },
+
+});
+
+export default Landing;

--- a/ui/app/main.jsx
+++ b/ui/app/main.jsx
@@ -1,11 +1,17 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { Router, Route, browserHistory } from 'react-router';
 import ProjectsView from './projects-view';
 import BuildsView from './builds-view';
+import ResultsView from './results-view';
 
 (function() {
     ReactDOM.render(
-        <ProjectsView />,
+        <Router history={browserHistory}>
+            <Route path="/" component={ProjectsView} />
+            <Route path="/:project_id/builds" component={BuildsView} />
+            <Route path="/:project_id/builds/:build_id/results" component={ResultsView} />
+        </Router>,
         document.getElementById('content')
     );
 })();

--- a/ui/app/main.jsx
+++ b/ui/app/main.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import Landing from './landing';
+import ProjectsView from './projects-view';
+import BuildsView from './builds-view';
 
 (function() {
     ReactDOM.render(
-        <Landing />,
+        <ProjectsView />,
         document.getElementById('content')
     );
 })();

--- a/ui/app/main.jsx
+++ b/ui/app/main.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import Landing from './landing';
 
 (function() {
     ReactDOM.render(
-        <p>Tetra!</p>,
+        <Landing />,
         document.getElementById('content')
     );
 })();

--- a/ui/app/projects-table.jsx
+++ b/ui/app/projects-table.jsx
@@ -1,0 +1,56 @@
+import React from 'react';
+
+/* TODO: "At this time Canon does not provide javascript for handling sorting" */
+var ProjectsTable = React.createClass({
+
+    render: function() {
+        return (
+            <table className="rs-list-table">
+                {this.tableHeaders()}
+                {this.tableEntries()}
+            </table>
+        );
+    },
+
+    tableHeaders: function() {
+        var headerNames = ["Id", "Name"];
+        return (
+            <thead>
+                <tr>
+                    <th className="rs-table-status"></th>
+                    { headerNames.map(this.tableHeader) }
+                </tr>
+            </thead>
+        );
+    },
+
+    tableHeader: function(headerName, i) {
+        return (
+            <th key={i}>
+                <a href="#list-table" className="rs-table-sort">
+                    <span className="rs-table-sort-text">{headerName}</span>
+                    <span className="rs-table-sort-indicator"></span>
+                </a>
+            </th>
+        );
+    },
+
+    tableEntries: function() {
+        var entries = [];
+        for (var i = 0; i < this.props.projects.length; i++) {
+            entries.push(
+                <tr key={i}>
+                    <td className="rs-table-status rs-table-status-ok"></td>
+                    <td>{this.props.projects[i].id}</td>
+                    <td>{this.props.projects[i].name}</td>
+                </tr>
+            );
+
+        }
+
+        return (<tbody>{entries}</tbody>);
+    },
+
+});
+
+export default ProjectsTable;

--- a/ui/app/projects-table.jsx
+++ b/ui/app/projects-table.jsx
@@ -1,54 +1,17 @@
 import React from 'react';
+import ResourceTable from './resource-table';
 
-/* TODO: "At this time Canon does not provide javascript for handling sorting" */
 var ProjectsTable = React.createClass({
+
+    // these are used as a column title. they are lowercased to access the
+    // field on the project resource - project["id"], project["name"]
+    columnKeys: ["Id", "Name"],
 
     render: function() {
         return (
-            <table className="rs-list-table">
-                {this.tableHeaders()}
-                {this.tableEntries()}
-            </table>
+            <ResourceTable resources={this.props.projects}
+                           columnKeys={this.columnKeys} />
         );
-    },
-
-    tableHeaders: function() {
-        var headerNames = ["Id", "Name"];
-        return (
-            <thead>
-                <tr>
-                    <th className="rs-table-status"></th>
-                    { headerNames.map(this.tableHeader) }
-                </tr>
-            </thead>
-        );
-    },
-
-    tableHeader: function(headerName, i) {
-        return (
-            <th key={i}>
-                <a href="#list-table" className="rs-table-sort">
-                    <span className="rs-table-sort-text">{headerName}</span>
-                    <span className="rs-table-sort-indicator"></span>
-                </a>
-            </th>
-        );
-    },
-
-    tableEntries: function() {
-        var entries = [];
-        for (var i = 0; i < this.props.projects.length; i++) {
-            entries.push(
-                <tr key={i}>
-                    <td className="rs-table-status rs-table-status-ok"></td>
-                    <td>{this.props.projects[i].id}</td>
-                    <td>{this.props.projects[i].name}</td>
-                </tr>
-            );
-
-        }
-
-        return (<tbody>{entries}</tbody>);
     },
 
 });

--- a/ui/app/projects-table.jsx
+++ b/ui/app/projects-table.jsx
@@ -5,18 +5,22 @@ var ProjectsTable = React.createClass({
 
     columnTitles: ["Id", "Name"],
     columnKeys: ["id", "name"],
+    columnLinks: {
+        "name": function(project) {
+            return "/" + project.id + "/builds";
+        },
+        "id": function(project) {
+            return "/" + project.id + "/builds";
+        },
+    },
 
     render: function() {
         return (
             <ResourceTable resources={this.props.projects}
                            columnTitles={this.columnTitles}
                            columnKeys={this.columnKeys}
-                           getRoute={this.getRoute} />
+                           columnLinks={this.columnLinks} />
         );
-    },
-
-    getRoute: function(project) {
-        return "/" + project.id + "/builds";
     },
 
 });

--- a/ui/app/projects-table.jsx
+++ b/ui/app/projects-table.jsx
@@ -3,13 +3,13 @@ import ResourceTable from './resource-table';
 
 var ProjectsTable = React.createClass({
 
-    // these are used as a column title. they are lowercased to access the
-    // field on the project resource - project["id"], project["name"]
-    columnKeys: ["Id", "Name"],
+    columnTitles: ["Id", "Name"],
+    columnKeys: ["id", "name"],
 
     render: function() {
         return (
             <ResourceTable resources={this.props.projects}
+                           columnTitles={this.columnTitles}
                            columnKeys={this.columnKeys}
                            getRoute={this.getRoute} />
         );

--- a/ui/app/projects-table.jsx
+++ b/ui/app/projects-table.jsx
@@ -10,8 +10,13 @@ var ProjectsTable = React.createClass({
     render: function() {
         return (
             <ResourceTable resources={this.props.projects}
-                           columnKeys={this.columnKeys} />
+                           columnKeys={this.columnKeys}
+                           getRoute={this.getRoute} />
         );
+    },
+
+    getRoute: function(project) {
+        return "/" + project.id + "/builds";
     },
 
 });

--- a/ui/app/projects-view.jsx
+++ b/ui/app/projects-view.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import ProjectsTable from './projects-table';
 
-var Landing = React.createClass({
+var ProjectsView = React.createClass({
 
     getInitialState: function() {
         return {
-            projects: [{id: 1, name: "poo", pee: "wumbo"}],
+            projects: [],
         }
     },
 
@@ -23,10 +23,13 @@ var Landing = React.createClass({
 
     render: function() {
         return (
-            <ProjectsTable projects={this.state.projects} />
+            <div>
+                <h2 className="rs-page-title">Projects</h2>
+                <ProjectsTable projects={this.state.projects} />
+            </div>
         );
     },
 
 });
 
-export default Landing;
+export default ProjectsView;

--- a/ui/app/resource-table-entry.jsx
+++ b/ui/app/resource-table-entry.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router';
 
 var ResourceTableEntry = React.createClass({
 
@@ -21,7 +22,9 @@ var ResourceTableEntry = React.createClass({
         for (var i = 0; i < columnKeys.length; i++) {
             var val = resource[columnKeys[i]];
             result.push(
-                <td key={i}> {val} </td>
+                <td key={i} className="rs-table-link">
+                    <Link to={this.props.link}> {val} </Link>
+                </td>
             );
         }
         return result;

--- a/ui/app/resource-table-entry.jsx
+++ b/ui/app/resource-table-entry.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+var ResourceTableEntry = React.createClass({
+
+    render: function() {
+        var resource = this.props.resource;
+        var columnKeys = this.props.columnKeys.map(function(name) {
+            return name.toLowerCase();
+        });
+        return (
+            <tr>
+                <td className="rs-table-status rs-table-status-ok"> </td>
+                { this.columns(resource, columnKeys) }
+            </tr>
+        );
+    },
+
+    // todo: we need to be able to configure the column order
+    columns: function(resource, columnKeys) {
+        var result = [];
+        for (var i = 0; i < columnKeys.length; i++) {
+            var val = resource[columnKeys[i]];
+            result.push(
+                <td key={i}> {val} </td>
+            );
+        }
+        return result;
+    },
+
+});
+
+export default ResourceTableEntry;

--- a/ui/app/resource-table-entry.jsx
+++ b/ui/app/resource-table-entry.jsx
@@ -5,27 +5,34 @@ var ResourceTableEntry = React.createClass({
 
     render: function() {
         var resource = this.props.resource;
-        var columnKeys = this.props.columnKeys.map(function(name) {
-            return name.toLowerCase();
-        });
+        var columnKeys = this.props.columnKeys;
+        var columnLinks = this.props.columnLinks;
         return (
             <tr>
                 <td className="rs-table-status rs-table-status-ok"> </td>
-                { this.columns(resource, columnKeys) }
+                { this.columns(resource, columnKeys, columnLinks) }
             </tr>
         );
     },
 
     // todo: we need to be able to configure the column order
-    columns: function(resource, columnKeys) {
+    columns: function(resource, columnKeys, columnLinks) {
         var result = [];
         for (var i = 0; i < columnKeys.length; i++) {
-            var val = resource[columnKeys[i]];
-            result.push(
-                <td key={i} className="rs-table-link">
-                    <Link to={this.props.link}> {val} </Link>
-                </td>
-            );
+            var key = columnKeys[i];
+            var val = resource[key];
+            if (columnLinks[key]) {
+                var link = columnLinks[key](resource);
+                result.push(
+                    <td key={i} className="rs-table-link">
+                        <Link to={link}> {val} </Link>
+                    </td>
+                );
+            } else {
+                result.push(
+                    <td key={i} className="rs-table-link"> {val} </td>
+                );
+            }
         }
         return result;
     },

--- a/ui/app/resource-table.jsx
+++ b/ui/app/resource-table.jsx
@@ -4,7 +4,7 @@ import ResourceTableEntry from './resource-table-entry';
 var ResourceTable = React.createClass({
 
     render: function() {
-        var headers = this.tableHeaders(this.props.columnKeys);
+        var headers = this.tableHeaders(this.props.columnTitles);
         var entries = this.tableEntries(this.props.resources,
                                         this.props.columnKeys);
         return (

--- a/ui/app/resource-table.jsx
+++ b/ui/app/resource-table.jsx
@@ -39,10 +39,16 @@ var ResourceTable = React.createClass({
     },
 
     tableEntries: function(resources, columnKeys) {
+        var getRoute = this.props.getRoute;
         var entries = resources.map(function(resource, i) {
+            var link = '';
+            if (getRoute) {
+                link = getRoute(resource);
+            }
             return <ResourceTableEntry key={i}
                                        resource={resource}
-                                       columnKeys={columnKeys} />
+                                       columnKeys={columnKeys}
+                                       link={link} />
         });
         return (<tbody>{entries}</tbody>);
     },

--- a/ui/app/resource-table.jsx
+++ b/ui/app/resource-table.jsx
@@ -39,16 +39,12 @@ var ResourceTable = React.createClass({
     },
 
     tableEntries: function(resources, columnKeys) {
-        var getRoute = this.props.getRoute;
+        var columnLinks = this.props.columnLinks;
         var entries = resources.map(function(resource, i) {
-            var link = '';
-            if (getRoute) {
-                link = getRoute(resource);
-            }
             return <ResourceTableEntry key={i}
                                        resource={resource}
                                        columnKeys={columnKeys}
-                                       link={link} />
+                                       columnLinks={columnLinks} />
         });
         return (<tbody>{entries}</tbody>);
     },

--- a/ui/app/resource-table.jsx
+++ b/ui/app/resource-table.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import ResourceTableEntry from './resource-table-entry';
+
+var ResourceTable = React.createClass({
+
+    render: function() {
+        var headers = this.tableHeaders(this.props.columnKeys);
+        var entries = this.tableEntries(this.props.resources,
+                                        this.props.columnKeys);
+        return (
+            <table className="rs-list-table">
+                {headers}
+                {entries}
+            </table>
+        );
+    },
+
+    tableHeaders: function(headerNames) {
+        return (
+            <thead>
+                <tr>
+                    <th className="rs-table-status"></th>
+                    { headerNames.map(this.tableHeader) }
+                </tr>
+            </thead>
+        );
+    },
+
+    /* TODO: "At this time Canon does not provide javascript for handling sorting" */
+    tableHeader: function(headerName, i) {
+        return (
+            <th key={i}>
+                <a href ="#list-table" className="rs-table-sort">
+                    <span className="rs-table-sort-text">{headerName}</span>
+                    <span className="rs-table-sort-indicator"></span>
+                </a>
+            </th>
+        );
+    },
+
+    tableEntries: function(resources, columnKeys) {
+        var entries = resources.map(function(resource, i) {
+            return <ResourceTableEntry key={i}
+                                       resource={resource}
+                                       columnKeys={columnKeys} />
+        });
+        return (<tbody>{entries}</tbody>);
+    },
+
+});
+
+export default ResourceTable;

--- a/ui/app/results-metadata.jsx
+++ b/ui/app/results-metadata.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+var ResultsMetadata = React.createClass({
+
+    render: function() {
+        return (
+            <ul className="rs-detail-list">
+                {this.items()}
+            </ul>
+        );
+    },
+
+    items: function() {
+        var metadata = this.props.metadata;
+        var items = [];
+        for (var key in metadata) {
+            items.push(
+                <li key={items.length} className="rs-detail-item">
+                    <div className="rs-detail-key">{key}</div>
+                    <div className="rs-detail-value">{metadata[key]}</div>
+                </li>
+            )
+        }
+        return items;
+    },
+
+});
+
+export default ResultsMetadata;

--- a/ui/app/results-table.jsx
+++ b/ui/app/results-table.jsx
@@ -11,12 +11,18 @@ var ResultsTable = React.createClass({
         "id", "build_id", "project_id", "result", "result_message",
         "test_name", "timestamp",
     ],
+    columnLinks: {
+        project_id: function(r) {
+            return "/" + r.project_id + "/builds";
+        },
+    },
 
     render: function() {
         return (
             <ResourceTable resources={this.props.results}
                            columnTitles={this.columnTitles}
-                           columnKeys={this.columnKeys} />
+                           columnKeys={this.columnKeys}
+                           columnLinks={this.columnLinks} />
         );
     },
 

--- a/ui/app/results-table.jsx
+++ b/ui/app/results-table.jsx
@@ -3,6 +3,10 @@ import ResourceTable from './resource-table';
 
 var ResultsTable = React.createClass({
 
+    columnTitles: [
+        "Id", "Build Id", "Project Id", "Result", "Result Message",
+        "Test Name", "Timestamp",
+    ],
     columnKeys: [
         "id", "build_id", "project_id", "result", "result_message",
         "test_name", "timestamp",
@@ -11,6 +15,7 @@ var ResultsTable = React.createClass({
     render: function() {
         return (
             <ResourceTable resources={this.props.results}
+                           columnTitles={this.columnTitles}
                            columnKeys={this.columnKeys} />
         );
     },

--- a/ui/app/results-table.jsx
+++ b/ui/app/results-table.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import ResourceTable from './resource-table';
+
+var ResultsTable = React.createClass({
+
+    columnKeys: [
+        "id", "build_id", "project_id", "result", "result_message",
+        "test_name", "timestamp",
+    ],
+
+    render: function() {
+        return (
+            <ResourceTable resources={this.props.results}
+                           columnKeys={this.columnKeys} />
+        );
+    },
+
+});
+
+export default ResultsTable;

--- a/ui/app/results-view.jsx
+++ b/ui/app/results-view.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import ResultsTable from './results-table';
+import ResultsMetadata from './results-metadata';
+
+var ResultsView = React.createClass({
+
+    getInitialState: function() {
+        return {
+            results: [],
+            metadata: {},
+        }
+    },
+
+    projectId: function() {
+        return this.props.params.project_id || this.props.project_id;
+    },
+
+    buildId: function() {
+        return this.props.params.build_id || this.props.build_id;
+    },
+
+    componentDidMount: function() {
+        var url = "/api/" + this.projectId() + "/builds/" + this.buildId() +
+                  "/results";
+        this.buildsRequest = $.get(url, function(result) {
+            this.setState({
+                results: result.results,
+                metadata: result.metadata,
+            })
+        }.bind(this))
+    },
+
+    componentWillUnmount: function() {
+        this.buildsRequest.abort();
+    },
+
+    render: function() {
+        return (
+            <div>
+                <h2 className="rs-page-title">Results</h2>
+                <h3>Summary</h3>
+                <ResultsMetadata metadata={this.state.metadata} />
+                <h3>All results</h3>
+                <ResultsTable results={this.state.results} />
+            </div>
+        );
+    },
+
+});
+
+export default ResultsView;

--- a/ui/nginx.conf
+++ b/ui/nginx.conf
@@ -2,19 +2,9 @@ server {
     listen 80 default_server;
     listen [::]:80 default_server;
 
-    location /api {
-        return 302 /api/;
-    }
     location /api/ {
         # "api" is the docker-compose service running the tetra api
-        proxy_pass          http://api/;
-        proxy_http_version  1.1;
-        proxy_set_header    Connection "";
-        proxy_set_header    Host $host;
-        proxy_set_header    X-Real-IP $remote_addr;
-        proxy_set_header    X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header    X-Forwarded-Proto $scheme;
-        proxy_read_timeout  600;
+        proxy_pass          http://api:7374/;
     }
 
     location / {

--- a/ui/package.json
+++ b/ui/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "scripts/build.sh",
-    "autobuild": "scripts/autobuild.sh"
+    "autobuild": "scripts/build.sh watch"
   },
   "babel": {
     "presets": [

--- a/ui/package.json
+++ b/ui/package.json
@@ -6,7 +6,8 @@
   "dependencies": {
     "canon-react": "^0.11.1",
     "react": "~0.14.8",
-    "react-dom": "~0.14.8"
+    "react-dom": "~0.14.8",
+    "react-router": "^2.4.1"
   },
   "devDependencies": {
     "babel-cli": "^6.9.0",

--- a/ui/scripts/autobuild.sh
+++ b/ui/scripts/autobuild.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-babel -w app -d dist &
-webpack -w dist/main.js dist/tetra.bundle.js &
-
-wait

--- a/ui/scripts/build.sh
+++ b/ui/scripts/build.sh
@@ -14,7 +14,7 @@ function run_babel() {
 }
 
 function run_webpack() {
-    webpack $1 --optimize-minimize
+    webpack $1  # --optimize-minimize
 
 }
 

--- a/ui/scripts/build.sh
+++ b/ui/scripts/build.sh
@@ -14,7 +14,7 @@ function run_babel() {
 }
 
 function run_webpack() {
-    webpack $1  # --optimize-minimize
+    webpack $1
 
 }
 

--- a/ui/scripts/build.sh
+++ b/ui/scripts/build.sh
@@ -1,4 +1,28 @@
 #!/bin/bash
+#
+# build once,
+#
+#     ./build.sh
+#
+# watch files and auto rebuild (any argument works),
+#
+#     ./build.sh watch
+#
 
-babel app -d dist
-webpack dist/main.js dist/tetra.bundle.js
+function run_babel() {
+    babel $1 app -d dist
+}
+
+function run_webpack() {
+    webpack $1 --optimize-minimize
+
+}
+
+if [ "$1" ]; then
+    run_webpack -w &
+    run_babel -w
+    wait
+else
+    run_babel
+    run_webpack
+fi

--- a/ui/webpack.config.js
+++ b/ui/webpack.config.js
@@ -1,0 +1,19 @@
+var webpack = require('webpack');
+
+module.exports = {
+    // babel will run and put all the files in .dist
+    entry: './dist/main.js',
+    output: {
+        path: './dist',
+        filename: 'tetra.bundle.js',
+    },
+
+    // disable warnings from third-party code
+    plugins: [
+        new webpack.optimize.UglifyJsPlugin({
+            compress: {
+                warnings: false
+            }
+        })
+    ],
+}


### PR DESCRIPTION
- [x] Fix the nginx config so we can access the api via `/api/` in our javascript. Enable request logging in gunicorn for debugging this sort of thing.
- [x] Use `webpack.config.js` for some of the webpack config, unify the two separate build scripts.
- [x] Use `.dockerignore` files to have docker ignore large useless directories like `.git` and `node_modules` which makes docker build faster.
- [x] Show projects, builds, and results tables. 
- [x] Use react router so navigating to different react components updates the address bar and browser history (like regular browsing).

Some todos for later:
- pagination and filtering don't work, it just displays the first page of items from the api
- display tags for builds, results
- color code results/builds based on the success rate
- instead of just `Results` or `Builds` as a title, we could have `Project 1 / Build 1 / Results` (breadcrumbs)
- tests for the ui