### PR TITLE
(feat): Add resource discovery on root api call

### DIFF
--- a/tests/api/test_versions.py
+++ b/tests/api/test_versions.py
@@ -1,0 +1,12 @@
+from tests.base import BaseTetraTest
+
+
+class TestVersion(BaseTetraTest):
+
+    def setUp(self):
+        super(TestVersion, self).setUp()
+
+    def test_list_projects(self):
+        resp = self.client.list_versions()
+        self.assertEqual(resp.status_code, 200)
+        self.assertGreater(len(resp.json()), 0)

--- a/tests/client.py
+++ b/tests/client.py
@@ -21,6 +21,13 @@ class BaseClient(object):
         return '/'.join(parts)
 
 
+class VersionClientMixin(BaseClient):
+
+    @log_response
+    def list_versions(self, params=None):
+        return requests.get(self.url('/'), params=params)
+
+
 class ProjectClientMixin(BaseClient):
 
     @log_response
@@ -37,22 +44,22 @@ class BuildClientMixin(BaseClient):
 
     @log_response
     def list_builds(self, project_id, params=None):
-        url = self.url(project_id, '/builds')
+        url = self.url('/projects', project_id, '/builds')
         return requests.get(url, params=params)
 
     @log_response
     def create_build(self, project_id, data, params=None):
-        url = self.url(project_id, '/builds')
+        url = self.url('/projects', project_id, '/builds')
         return requests.post(url, data=json.dumps(data), params=params)
 
     @log_response
     def get_build(self, project_id, build_id, params=None):
-        url = self.url(project_id, '/builds', build_id)
+        url = self.url('/projects', project_id, '/builds', build_id)
         return requests.get(url, params=params)
 
     @log_response
     def delete_build(self, project_id, build_id, params=None):
-        url = self.url(project_id, '/builds', build_id)
+        url = self.url('/projects', project_id, '/builds', build_id)
         return requests.delete(url, params=params)
 
 
@@ -60,30 +67,35 @@ class ResultClientMixin(BaseClient):
 
     @log_response
     def list_results(self, project_id, build_id, params=None):
-        url = self.url(project_id, '/builds', build_id, '/results')
+        url = self.url('/projects', project_id,
+                       '/builds', build_id, '/results')
         return requests.get(url, params=params)
 
     @log_response
     def create_result(self, project_id, build_id, data, params=None,
                       headers=None):
-        url = self.url(project_id, '/builds', build_id, '/results')
+        url = self.url('/projects', project_id,
+                       '/builds', build_id, '/results')
         return requests.post(url, data=json.dumps(data), params=params,
                              headers=headers)
 
     @log_response
     def create_result_junit_xml(self, project_id, build_id, data, params=None,
                                 headers=None):
-        url = self.url(project_id, '/builds', build_id, '/results')
+        url = self.url('/projects', project_id,
+                       '/builds', build_id, '/results')
         return requests.post(url, data=data, params=params, headers=headers)
 
     @log_response
     def get_result(self, project_id, build_id, result_id, params=None):
-        url = self.url(project_id, '/builds', build_id, '/results', result_id)
+        url = self.url('/projects', project_id,
+                       '/builds', build_id, '/results', result_id)
         return requests.get(url, params=params)
 
     @log_response
     def delete_result(self, project_id, build_id, result_id, params=None):
-        url = self.url(project_id, '/builds', build_id, '/results', result_id)
+        url = self.url('/projects', project_id,
+                       '/builds', build_id, '/results', result_id)
         return requests.delete(url, params=params)
 
 
@@ -96,6 +108,7 @@ class WorkerClientMixin(BaseClient):
 
 
 class TetraClient(
+    VersionClientMixin,
     ProjectClientMixin,
     BuildClientMixin,
     ResultClientMixin,

--- a/tetra/api/resources.py
+++ b/tetra/api/resources.py
@@ -72,27 +72,6 @@ class Resource(object):
         self.RESOURCE_CLASS.delete(resource_id=resource_id)
 
 
-class VersionResource(Resources):
-    ROUTE = "/"
-
-    def on_get(self, req, resp):
-        resp.status = falcon.HTTP_200
-        # build a json response based on all ROUTE
-        routes = [self.get_route(cl) for cl in
-                  inspect.getmembers(sys.modules[__name__], inspect.isclass)
-                  if self.get_route(cl) is not None]
-
-        version = {
-                'version': 'v1',
-                'resources': routes
-                }
-        resp.body = json.dumps(version)
-
-    def get_route(self, cl):
-        if cl[0].endswith('Resource') and hasattr(cl[1], 'ROUTE'):
-            return cl[1].ROUTE
-
-
 class ProjectsResource(Resources):
     ROUTE = "/projects"
     RESOURCE_CLASS = Project

--- a/tetra/api/resources.py
+++ b/tetra/api/resources.py
@@ -16,8 +16,6 @@ limitations under the License.
 import falcon
 import json
 
-import inspect
-import sys
 import xunitparser
 
 from tetra.data.models.build import Build

--- a/tetra/app.py
+++ b/tetra/app.py
@@ -14,18 +14,34 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import falcon
+import json
 
 from api.resources import (
     BuildResource,
     ResultResource,
     ResultsResource,
     BuildsResource,
-    ProjectsResource,
-    VersionResource
+    ProjectsResource
 )
 from worker.resources import (
     WorkerPingResource,
 )
+
+
+class VersionResource(object):
+    ROUTE = "/"
+
+    def on_get(self, req, resp):
+        resp.status = falcon.HTTP_200
+        # build a json response based on all ROUTE
+        routes = [cl.ROUTE for cl in
+                  TetraAPI.RESOURCES]
+
+        version = {
+                'version': 'v1',
+                'resources': routes
+                }
+        resp.body = json.dumps(version)
 
 
 class TetraAPI(falcon.API):

--- a/tetra/app.py
+++ b/tetra/app.py
@@ -21,6 +21,7 @@ from api.resources import (
     ResultsResource,
     BuildsResource,
     ProjectsResource,
+    VersionResource
 )
 from worker.resources import (
     WorkerPingResource,
@@ -35,6 +36,7 @@ class TetraAPI(falcon.API):
         ResultResource(),
         BuildsResource(),
         ProjectsResource(),
+        VersionResource(),
         WorkerPingResource(),
     ]
 

--- a/ui/app/builds-table.jsx
+++ b/ui/app/builds-table.jsx
@@ -11,10 +11,10 @@ var BuildsTable = React.createClass({
     ],
     columnLinks: {
         name: function(build) {
-            return "/" + build.project_id + "/builds/" + build.id + "/results";
+            return "/projects/" + build.project_id + "/builds/" + build.id + "/results";
         },
         id: function(build) {
-            return "/" + build.project_id + "/builds/" + build.id + "/results";
+            return "/projects/" + build.project_id + "/builds/" + build.id + "/results";
         },
     },
 

--- a/ui/app/builds-view.jsx
+++ b/ui/app/builds-view.jsx
@@ -14,7 +14,7 @@ var BuildsView = React.createClass({
     },
 
     componentDidMount: function() {
-        var url = "/api/" + this.projectId() + "/builds";
+        var url = "/api/projects/" + this.projectId() + "/builds";
         this.buildsRequest = $.get(url, function(result) {
             this.setState({
                 builds: result

--- a/ui/app/main.jsx
+++ b/ui/app/main.jsx
@@ -8,9 +8,9 @@ import ResultsView from './results-view';
 (function() {
     ReactDOM.render(
         <Router history={browserHistory}>
-            <Route path="/" component={ProjectsView} />
-            <Route path="/:project_id/builds" component={BuildsView} />
-            <Route path="/:project_id/builds/:build_id/results" component={ResultsView} />
+            <Route path="/projects" component={ProjectsView} />
+            <Route path="/projects/:project_id/builds" component={BuildsView} />
+            <Route path="/projects/:project_id/builds/:build_id/results" component={ResultsView} />
         </Router>,
         document.getElementById('content')
     );

--- a/ui/app/projects-table.jsx
+++ b/ui/app/projects-table.jsx
@@ -7,10 +7,10 @@ var ProjectsTable = React.createClass({
     columnKeys: ["id", "name"],
     columnLinks: {
         "name": function(project) {
-            return "/" + project.id + "/builds";
+            return "/projects/" + project.id + "/builds";
         },
         "id": function(project) {
-            return "/" + project.id + "/builds";
+            return "/projects/" + project.id + "/builds";
         },
     },
 

--- a/ui/app/results-table.jsx
+++ b/ui/app/results-table.jsx
@@ -13,7 +13,7 @@ var ResultsTable = React.createClass({
     ],
     columnLinks: {
         project_id: function(r) {
-            return "/" + r.project_id + "/builds";
+            return "/projects/" + r.project_id + "/builds";
         },
     },
 

--- a/ui/app/results-view.jsx
+++ b/ui/app/results-view.jsx
@@ -20,7 +20,7 @@ var ResultsView = React.createClass({
     },
 
     componentDidMount: function() {
-        var url = "/api/" + this.projectId() + "/builds/" + this.buildId() +
+        var url = "/api/projects/" + this.projectId() + "/builds/" + this.buildId() +
                   "/results";
         this.buildsRequest = $.get(url, function(result) {
             this.setState({


### PR DESCRIPTION
On /, we now get a json response with all available resources

This PR also prepends /projects to existing projects resources to keep in line with the rest of the API pattern.