### PR TITLE
Truncate user input to fit in the database

### DIFF
--- a/tests/api/test_builds.py
+++ b/tests/api/test_builds.py
@@ -3,14 +3,18 @@ import unittest
 from tests.base import BaseTetraTest
 
 
-class TestBuilds(BaseTetraTest):
+class BaseBuildsTest(BaseTetraTest):
 
     def setUp(self):
-        super(TestBuilds, self).setUp()
-
+        super(BaseBuildsTest, self).setUp()
         resp = self._create_project()
         self.project_id = resp.json()['id']
 
+
+class TestBuilds(BaseBuildsTest):
+
+    def setUp(self):
+        super(TestBuilds, self).setUp()
         self.create_resp = self._create_build(
             self.project_id, name='test-build', build_url='test-url',
             region='test-region', environment='test-env')
@@ -44,3 +48,24 @@ class TestBuilds(BaseTetraTest):
         # TODO(pglass): deleting an already-deleted build returns a 204
         # resp = self.client.delete_build(self.project_id, self.build['id'])
         # self.assertEqual(resp.status_code, 404)
+
+
+class TestBuildsStringTruncation(BaseBuildsTest):
+    """Test that the api truncates user input to fit in database columns"""
+
+    def test_api_truncates_long_build_fields(self):
+        long_str = "a" * 257
+
+        create_resp = self._create_build(
+            project_id=self.project_id,
+            name=long_str,
+            build_url=long_str,
+            region=long_str,
+            environment=long_str,
+        )
+        build = create_resp.json()
+
+        self.assertEqual(len(build['name']), 256)
+        self.assertEqual(len(build['build_url']), 256)
+        self.assertEqual(len(build['region']), 256)
+        self.assertEqual(len(build['environment']), 256)

--- a/tests/api/test_projects.py
+++ b/tests/api/test_projects.py
@@ -16,3 +16,12 @@ class TestProjects(BaseTetraTest):
         project = self.create_resp.json()
         self.assertEqual(project['name'], 'test-project')
         self.assertIn('id', project)
+
+
+class TestProjectStringTruncation(BaseTetraTest):
+    """Test that the api truncates user input to fit in database columns"""
+
+    def test_api_truncates_long_project_fields(self):
+        create_resp = self._create_project(name="a" * 257)
+        project = create_resp.json()
+        self.assertEqual(len(project['name']), 256)

--- a/tests/api/test_results.py
+++ b/tests/api/test_results.py
@@ -271,3 +271,19 @@ class TestLastCountByStatusResults(BaseResultTest):
         for i in results:
             self.assertEqual(i['result'], 'passed')
             self.assertEqual(i['build_id'], self.build_id_two)
+
+
+class TestResultStringTuncation(BaseResultTest):
+    """Test that the api truncates user input to fit in database columns"""
+
+    def test_api_truncates_result_fields(self):
+        long_str = "a" * 257
+        create_resp = self._create_result(
+            project_id=self.project_id,
+            build_id=self.build_id,
+            test_name=long_str,
+            result=long_str,
+        )
+        result = create_resp.json()
+        self.assertEqual(len(result['test_name']), 256)
+        self.assertEqual(len(result['result']), 256)

--- a/tetra/data/models/base.py
+++ b/tetra/data/models/base.py
@@ -21,6 +21,13 @@ from tetra.data.db_handler import get_handler
 conf = cfg.CONF
 
 
+def truncate(value, length):
+    """Truncate the value (a string) to the given length."""
+    if value is None:
+        return None
+    return value[:length]
+
+
 class DictSerializer(object):
 
     @classmethod

--- a/tetra/data/models/build.py
+++ b/tetra/data/models/build.py
@@ -17,7 +17,7 @@ from sqlalchemy import and_, text, select
 
 from tetra.data import sql
 from tetra.data.db_handler import get_handler
-from tetra.data.models.base import BaseModel
+from tetra.data.models.base import BaseModel, truncate
 from tetra.data.models.tags import Tag
 
 
@@ -31,10 +31,12 @@ class Build(BaseModel):
         if id:
             self.id = int(id)
         self.project_id = int(project_id)
-        self.name = name
-        self.build_url = build_url
-        self.region = region
-        self.environment = environment
+        self.name = truncate(name, self.TABLE.c.name.type.length)
+        self.build_url = truncate(build_url,
+                                  self.TABLE.c.build_url.type.length)
+        self.region = truncate(region, self.TABLE.c.region.type.length)
+        self.environment = truncate(environment,
+                                    self.TABLE.c.environment.type.length)
 
     @classmethod
     def get_all(cls, handler=None, limit=None, offset=None, project_id=None,

--- a/tetra/data/models/project.py
+++ b/tetra/data/models/project.py
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 from tetra.data import sql
-from tetra.data.models.base import BaseModel
+from tetra.data.models.base import BaseModel, truncate
 
 
 class Project(BaseModel):
@@ -24,4 +24,4 @@ class Project(BaseModel):
     def __init__(self, name, id=None):
         if id:
             self.id = id
-        self.name = name
+        self.name = truncate(name, self.TABLE.c.name.type.length)

--- a/tetra/data/models/result.py
+++ b/tetra/data/models/result.py
@@ -20,7 +20,7 @@ from sqlalchemy.sql import func, select, and_
 
 from tetra.data import sql
 from tetra.data.db_handler import get_handler
-from tetra.data.models.base import BaseModel
+from tetra.data.models.base import BaseModel, truncate
 from tetra.data.models.build import Build
 from tetra.data.models.result_metadata import ResultMetadata
 
@@ -33,11 +33,13 @@ class Result(BaseModel):
                  timestamp=None,  result_message=None):
         if id:
             self.id = int(id)
-        self.test_name = test_name
+
+        self.test_name = truncate(test_name,
+                                  self.TABLE.c.test_name.type.length)
         self.project_id = int(project_id)
         self.build_id = int(build_id)
         self.timestamp = timestamp or time.time()
-        self.result = result
+        self.result = truncate(result, self.TABLE.c.result.type.length)
         self.result_message = result_message
 
     @classmethod


### PR DESCRIPTION
This ensures that all user input to the api which overflows a database
column string type (like varchar) is truncated to fit.

Fixes #27