### PR TITLE
Column status color

### DIFF
--- a/ui/app/resource-table-entry.jsx
+++ b/ui/app/resource-table-entry.jsx
@@ -53,10 +53,13 @@ var ResourceTableEntry = React.createClass({
         var status = resource["result"] || resource["status"];
         if (status == "failed" || status == "error") {
             return <td className="rs-table-status rs-table-status-error"> </td>;
-        } else if (status == "skipped"){
+        } else if (status == "skipped") {
             return <td className="rs-table-status rs-table-status-warning"> </td>;
+        } else if (status == "passed") {
+            return <td className="rs-table-status rs-table-status-ok"> </td>;
+        } else {
+            return <td className="rs-table-status rs-table-status-disabled"> </td>;
         }
-        return <td className="rs-table-status rs-table-status-ok"> </td>;
     },
 
 });

--- a/ui/app/resource-table-entry.jsx
+++ b/ui/app/resource-table-entry.jsx
@@ -9,7 +9,7 @@ var ResourceTableEntry = React.createClass({
         var columnLinks = this.props.columnLinks;
         return (
             <tr>
-                <td className="rs-table-status rs-table-status-ok"> </td>
+                { this.status(resource) }
                 { this.columns(resource, columnKeys, columnLinks) }
             </tr>
         );
@@ -47,6 +47,16 @@ var ResourceTableEntry = React.createClass({
             }
         }
         return result;
+    },
+
+    status:  function(resource) {
+        var status = resource["result"] || resource["status"];
+        if (status == "failed" || status == "error") {
+            return <td className="rs-table-status rs-table-status-error"> </td>;
+        } else if (status == "skipped"){
+            return <td className="rs-table-status rs-table-status-warning"> </td>;
+        }
+        return <td className="rs-table-status rs-table-status-ok"> </td>;
     },
 
 });

--- a/ui/app/resource-table-entry.jsx
+++ b/ui/app/resource-table-entry.jsx
@@ -51,11 +51,11 @@ var ResourceTableEntry = React.createClass({
 
     status:  function(resource) {
         var status = resource["result"] || resource["status"];
-        if (status == "failed" || status == "error") {
+        if (status === "failed" || status === "error") {
             return <td className="rs-table-status rs-table-status-error"> </td>;
-        } else if (status == "skipped") {
+        } else if (status === "skipped") {
             return <td className="rs-table-status rs-table-status-warning"> </td>;
-        } else if (status == "passed") {
+        } else if (status === "passed") {
             return <td className="rs-table-status rs-table-status-ok"> </td>;
         } else {
             return <td className="rs-table-status rs-table-status-disabled"> </td>;


### PR DESCRIPTION
I used gray for elements that either don't have statuses or have custom statuses beyond passed/failed/skipped/error because it looked weird if it just didn't have a colored column. We can change it to something else if we think the gray will confuse people who instinctively think "disabled" when they see that color, though.

![screenshot from 2016-08-14 02 10 08](https://cloud.githubusercontent.com/assets/3768460/17647757/5e6d1164-61c5-11e6-8966-df63c5db6bb2.png)
![screenshot from 2016-08-14 02 16 25](https://cloud.githubusercontent.com/assets/3768460/17647758/6378e61a-61c5-11e6-8918-b2207785e1e1.png)


